### PR TITLE
v0.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # 📰 Treestamps News
 
+## v0.1.2
+
+- Features
+
+  - colored output.
+
+- Fixes
+
+  - Trap more errors when reading timestamps
+
 ## v0.1.1
 
 - Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # 📰 Treestamps News
 
-## v0.1.4
+## v0.2.0
 
 - Features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # 📰 Treestamps News
 
+## v0.2.1
+
+- Fix
+
+  - Support ignore in factory
+
 ## v0.2.0
 
 - Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # 📰 Treestamps News
 
+## v0.1.1
+
+- Fixes
+
+  - Fix strings submitted to factory instead of paths
+
 ## v0.1.0
 
 _First Release_

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # 📰 Treestamps News
 
+## v0.1.4
+
+- Features
+
+  - Support ignore globs
+
 ## v0.1.3
 
 - Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # 📰 Treestamps News
 
+## v0.1.3
+
+- Fixes
+
+  - Protect final dump yaml from child cleanup task.
+
 ## v0.1.2
 
 - Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # 📰 Treestamps News
 
+## v0.3.0
+
+- Fix
+
+  - Fix factory consuming child timestamps when given files not directories.
+  - Fix loading and dumping timestamps not related to the treestamp dir.
+
+- Features
+
+  - Ignore symlinks option.
+
 ## v0.2.1
 
 - Fix

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A library to set and retrieve timestamps to speed up operations
 run recursively on directory trees.
 
-Principal methodds on the Treestamps class are: init(), get(), set(), dump().
+Principal methods on the Treestamps class are: init(), get(), set(), dump().
 A factory method is also provided for creating top path to Treestamp maps.
 
 Documentation is to read the code for now.

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,19 +133,19 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -909,12 +909,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -925,7 +925,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -941,7 +941,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -1127,13 +1127,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -6517,19 +6517,19 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -7138,12 +7138,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -7154,7 +7154,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -7170,7 +7170,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -7289,13 +7289,13 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "timestamps",
+  "name": "treestamps",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -459,7 +459,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyright"
-version = "1.1.244"
+version = "1.1.245"
 description = "Command line wrapper for pyright"
 category = "dev"
 optional = false
@@ -1045,8 +1045,8 @@ pyparsing = [
     {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
 ]
 pyright = [
-    {file = "pyright-1.1.244-py3-none-any.whl", hash = "sha256:b12c186320b932d15b6e6f85b08077ca688c6ae572d8a6fef58ba3c0f9eca1d4"},
-    {file = "pyright-1.1.244.tar.gz", hash = "sha256:24aca93b33a72345cffcfcecd303b77bf53f08a54235f9949f51df7d4287fd57"},
+    {file = "pyright-1.1.245-py3-none-any.whl", hash = "sha256:1edfb44ea6318e4648e4d522d1d164774dd487e27cb954d202cbf7e9cf28d597"},
+    {file = "pyright-1.1.245.tar.gz", hash = "sha256:cbbd743f9de2b96b35a03b9b8f2d2b046f292c9967468b9a38132319954ddbf2"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -339,7 +339,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "pbr"
-version = "5.8.1"
+version = "5.9.0"
 description = "Python Build Reasonableness"
 category = "dev"
 optional = false
@@ -1002,8 +1002,8 @@ pathspec = [
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 pbr = [
-    {file = "pbr-5.8.1-py2.py3-none-any.whl", hash = "sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec"},
-    {file = "pbr-5.8.1.tar.gz", hash = "sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25"},
+    {file = "pbr-5.9.0-py2.py3-none-any.whl", hash = "sha256:e547125940bcc052856ded43be8e101f63828c2d94239ffbe2b327ba3d5ccf0a"},
+    {file = "pbr-5.9.0.tar.gz", hash = "sha256:e8dca2f4b43560edef58813969f52a56cef023146cbb8931626db80e6c1c4308"},
 ]
 pep8-naming = [
     {file = "pep8-naming-0.12.1.tar.gz", hash = "sha256:bb2455947757d162aa4cad55dba4ce029005cd1692f2899a21d51d8630ca7841"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -660,6 +660,14 @@ python-versions = ">=3.6"
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -709,7 +717,7 @@ toml = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6bc7e97961a3e535bfccb8c2a839954e951d8d1bda9a05d82edac421774bc3e9"
+content-hash = "037c65bf877280e728c3536a91ad24191ebc47b7462dd5b883a74454d9063adf"
 
 [metadata.files]
 atomicwrites = [
@@ -1155,6 +1163,9 @@ snowballstemmer = [
 stevedore = [
     {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},
     {file = "stevedore-3.5.0.tar.gz", hash = "sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.1.2"
+version = "0.1.3"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.2.0"
+version = "0.2.1"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.1.1"
+version = "0.1.2"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"
@@ -27,6 +27,7 @@ include = ["NEWS.md"]
 [tool.poetry.dependencies]
 python = "^3.9"
 "ruamel.yaml" = "^0.17.21"
+termcolor = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 codespell = "^2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.1.0"
+version = "0.1.1"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.2.1"
+version = "0.3.0"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "treestamps"
-version = "0.1.3"
+version = "0.2.0"
 description = "Create timestamp records for recursive operations on directory trees."
 authors = ["AJ Slater <aj@slater.net>"]
 license = "GPL-3.0-only"

--- a/tests/unit/test_classmethods.py
+++ b/tests/unit/test_classmethods.py
@@ -33,9 +33,7 @@ class TestClassMethodds:
 
         paths = (path_a, path_b, path_c)
 
-        program_name = "foo"
-
-        map = Treestamps.path_to_treestamps_map_factory(paths, program_name)
+        map = Treestamps.map_factory(paths, "foo")
 
         dirset = set([path_b, path_c])
         assert set(map.keys()) == dirset

--- a/treestamps.py
+++ b/treestamps.py
@@ -18,6 +18,7 @@ class Treestamps:
     @staticmethod
     def dirpath(path: Path):
         """Return a directory for a path."""
+        path = Path(path)
         return path if path.is_dir() else path.parent
 
     @staticmethod
@@ -254,6 +255,7 @@ class Treestamps:
         config_allowed_keys: Optional[set[str]] = None,
     ) -> None:
         """Initialize instance variables."""
+        dir = Path(dir)
         if not dir.is_dir():
             raise ValueError("'dir' argument must be a directory")
         self.dir = dir

--- a/treestamps.py
+++ b/treestamps.py
@@ -176,7 +176,8 @@ class Treestamps:
             if not path.is_file():
                 return
             self._load_timestamps_file(path)
-            self._consumed_paths.add(path)
+            if path != self._dump_path:
+                self._consumed_paths.add(path)
             if self._verbose:
                 print(f"Read timestamps from {path}")
         except Exception as exc:
@@ -338,9 +339,10 @@ class Treestamps:
         dumpable_timestamps = self._serialize_timestamps()
         yaml.update(dumpable_timestamps)
 
-        self._YAML.dump(yaml, self._dump_path)
         self._close_wal()
+        self._YAML.dump(yaml, self._dump_path)
         if self._consumed_paths:
+            self._consumed_paths.discard(self._dump_path)
             for path in self._consumed_paths:
                 try:
                     path.unlink(missing_ok=True)

--- a/treestamps.py
+++ b/treestamps.py
@@ -91,7 +91,6 @@ class Treestamps:
 
         dirs = []
         files = []
-        #
         # This order creates dir based treestamps before files
         # So dirs get children recursed and files only don't.
         for path in paths:

--- a/treestamps.py
+++ b/treestamps.py
@@ -77,6 +77,7 @@ class Treestamps:
         paths: Iterable[Path],
         program_name: str,
         verbose: int = 0,
+        ignore: Optional[list[str]] = None,
         config: Optional[dict] = None,
         config_allowed_keys: Optional[set] = None,
     ):
@@ -90,7 +91,11 @@ class Treestamps:
             if top_path in map:
                 continue
             map[top_path] = Treestamps(
-                program_name, top_path, verbose=verbose, config=timestamps_config
+                program_name,
+                top_path,
+                verbose=verbose,
+                ignore=ignore,
+                config=timestamps_config,
             )
         return map
 


### PR DESCRIPTION
- Fix

  - Fix factory consuming child timestamps when given files not directories.
  - Fix loading and dumping timestamps not related to the treestamp dir.

- Features

  - Ignore symlinks option.
  - Rename `config` param to `program_config`