### PR TITLE
Add pickle support for CommonConfig with MappingProxyType

### DIFF
--- a/tests/unit/test_classmethods.py
+++ b/tests/unit/test_classmethods.py
@@ -1,5 +1,6 @@
 """Test classmethods."""
 
+import pickle
 from pathlib import Path
 from types import MappingProxyType
 
@@ -9,7 +10,7 @@ from treestamps.tree import Treestamps
 __all__ = ()
 
 
-class TestClassMethodds:
+class TestClassMethods:
     """Test classmethods."""
 
     def test_get_filename(self) -> None:
@@ -50,6 +51,25 @@ class TestClassMethodds:
             "Dummy", program_config_keys=keys, program_config={"a": {"b": [2, 1, 3, 1]}}
         )
         assert cc.program_config == MappingProxyType({"a": {"b": (1, 1, 2, 3)}})
+
+    def test_pickle_config_none(self) -> None:
+        """Test pickling config with no program_config."""
+        cc = GrovestampsConfig("Dummy")
+        restored = pickle.loads(pickle.dumps(cc))
+        assert restored.program_config is None
+        assert restored.program_name == "Dummy"
+
+    def test_pickle_config_with_nested_data(self) -> None:
+        """Test pickling config with nested program_config."""
+        keys = frozenset(["key"])
+        cc = GrovestampsConfig(
+            "Dummy",
+            program_config_keys=keys,
+            program_config={"key": {"nested": [3, 1, 2]}},
+        )
+        restored = pickle.loads(pickle.dumps(cc))
+        assert restored.program_config == cc.program_config
+        assert type(restored.program_config) is MappingProxyType
 
     def test_grove(self) -> None:
         """Test the factory."""

--- a/treestamps/config.py
+++ b/treestamps/config.py
@@ -61,3 +61,28 @@ class CommonConfig(ABC):
             self.program_config = MappingProxyType(
                 dict(self.normalize_config(filtered_program_config))
             )
+
+    @classmethod
+    def _denormalize(cls, value: Any) -> Any:
+        """Recursively convert MappingProxyType back to dict for pickling."""
+        if isinstance(value, MappingProxyType):
+            return {k: cls._denormalize(v) for k, v in value.items()}
+        if isinstance(value, (tuple, frozenset)):
+            converted = [cls._denormalize(v) for v in value]
+            return type(value)(converted)
+        return value
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Convert MappingProxyType to dict for pickling."""
+        state = self.__dict__.copy()
+        if state.get("program_config") is not None:
+            state["program_config"] = self._denormalize(state["program_config"])
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Re-normalize after unpickling to restore MappingProxyType wrappers."""
+        self.__dict__.update(state)
+        if self.program_config is not None:
+            self.program_config = MappingProxyType(
+                dict(self.normalize_config(self.program_config))
+            )


### PR DESCRIPTION
## Changes

- Implement `__getstate__` and `__setstate__` methods in `CommonConfig` to handle pickling of `MappingProxyType` objects
- Add `_denormalize` classmethod to recursively convert `MappingProxyType` back to dict for serialization
- Add comprehensive unit tests for pickling config objects with and without nested data
- Fix typo in test class name (`TestClassMethodds` → `TestClassMethods`)

## Summary

Enables proper serialization and deserialization of `CommonConfig` instances by converting immutable `MappingProxyType` objects to dicts during pickling and restoring them afterward.