### PR TITLE
Parameterize CI image/container names from repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
     branches: [main, develop]
 
 env:
-  BUILDER_IMAGE: ghcr.io/${{ github.repository }}/treestamps-builder
+  BUILDER_IMAGE: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}-builder
+  CI_IMAGE: ${{ github.event.repository.name }}-ci:ci
+  CI_CONTAINER: ${{ github.event.repository.name }}-ci
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 concurrency:
@@ -63,7 +65,7 @@ jobs:
         with:
           context: .
           load: true
-          tags: treestamps-ci:ci
+          tags: ${{ env.CI_IMAGE }}
           cache-from: type=registry,ref=${{ env.BUILDER_IMAGE }}:cache
           cache-to: type=registry,ref=${{ env.BUILDER_IMAGE }}:cache,mode=max
 
@@ -75,16 +77,16 @@ jobs:
 
       - name: Lint
         if: steps.gate.outputs.dist_found != 'true'
-        run: docker exec treestamps-ci make lint
+        run: docker exec $CI_CONTAINER make lint
 
       - name: Tests
         id: tests
         if: steps.gate.outputs.dist_found != 'true'
-        run: docker exec treestamps-ci make test
+        run: docker exec $CI_CONTAINER make test
 
       - name: Build Distribution
         if: steps.gate.outputs.dist_found != 'true'
-        run: docker exec treestamps-ci make build
+        run: docker exec $CI_CONTAINER make build
 
       - name: Upload Test Results
         id: upload-tests

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,9 +2,8 @@ services:
   ci:
     build:
       context: .
-      target: treestamps-ci
-    image: treestamps-ci:ci
-    container_name: treestamps-ci
+    image: ${CI_IMAGE}
+    container_name: ${CI_CONTAINER}
     volumes:
       - ./test-results:/app/test-results
       - ./dist:/app/dist


### PR DESCRIPTION
Derive CI_IMAGE, CI_CONTAINER, and BUILDER_IMAGE from github.event.repository.name so the workflow and compose.yaml are portable across repos without hardcoded project names.