### PR TITLE
Fix dumpf crash on parent-yaml above-root entries (v4.0.2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # 📰 Treestamps News
 
+## v4.0.2
+
+- Fix `dumpf` crash when a parent-of-root yaml contains an entry pointing
+  at the parent directory itself. Such entries are now clamped to
+  `root_dir` on load (matching the v3 semantic: a timestamp on an
+  ancestor of the tree applies to the tree as a whole), instead of being
+  stored above-root and crashing `_serialize_timestamps`.
+
 ## v4.0.1
 
 - Grove.dumpf returns a tuple of all paths which dumped treestamps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["directory", "library", "recursive", "timestamps"]
 readme = "README.md"
 requires-python = ">=3.10"
 name = "treestamps"
-version = "4.0.1"
+version = "4.0.2"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/tests/integration/test_parent_load.py
+++ b/tests/integration/test_parent_load.py
@@ -1,0 +1,74 @@
+"""Loading a parent yaml with an above-root entry must not crash on dump."""
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from tests import PROGRAM
+from tests.integration.base_test import BaseTestDir
+from treestamps.grove import Grovestamps, GrovestampsConfig
+
+__all__ = ()
+
+PROGRAM_NAME = f"{PROGRAM}-tests-parent-load"
+TS_FN = f".{PROGRAM_NAME}_treestamps.yaml"
+
+
+class TestParentLoad(BaseTestDir):
+    """Loading parent timestamps that point at the parent itself."""
+
+    @staticmethod
+    def _write_parent_yaml(parent_dir: Path, abs_path_key: str, ts: float) -> None:
+        """Write a treestamps yaml at ``parent_dir`` with an above-root entry."""
+        yaml_obj = YAML()
+        ts_config = {"ignore": frozenset(), "symlinks": True}
+        yaml = {
+            "config": {},
+            "treestamps_config": ts_config,
+            abs_path_key: ts,
+        }
+        # Custom representer for frozenset (matches treestamps's own dump).
+        from ruamel.yaml import SafeRepresenter
+
+        yaml_obj.representer.add_representer(
+            frozenset, SafeRepresenter.represent_set
+        )
+        yaml_obj.dump(yaml, parent_dir / TS_FN)
+
+    def test_parent_yaml_entry_above_root_dumpf(self) -> None:
+        """
+        Parent-yaml above-root entry must not crash dumpf.
+
+        A parent yaml whose only entry is the parent dir itself must not
+        crash ``dumpf`` on a child-rooted Grovestamps.
+
+        Regression: v4.0.0/4.0.1 stored the above-root entry under its
+        absolute path, then ``_serialize_timestamps`` called
+        ``abs_path.relative_to(self.root_dir)`` and raised ``ValueError``
+        because the entry was outside the tree.
+        """
+        child_dir = self.TMP_ROOT / "child"
+        child_dir.mkdir()
+
+        # Parent yaml lists the parent dir itself as the only entry.
+        ts = 1_700_000_000.0
+        self._write_parent_yaml(self.TMP_ROOT, str(self.TMP_ROOT), ts)
+
+        config = GrovestampsConfig(
+            program_name=PROGRAM_NAME,
+            paths=(child_dir,),
+            verbose=0,
+            check_config=False,
+        )
+        gs = Grovestamps(config)
+
+        # Lookup for any path under the child should inherit the parent ts.
+        loaded = gs[child_dir].get(child_dir / "anything.txt")
+        assert loaded == ts
+
+        # The crash this test exists to prevent.
+        gs.dumpf()
+
+        # Child yaml should now exist with a single root-relative entry.
+        child_yaml = child_dir / TS_FN
+        assert child_yaml.exists()

--- a/tests/integration/test_parent_load.py
+++ b/tests/integration/test_parent_load.py
@@ -53,6 +53,9 @@ class TestParentLoad(BaseTestDir):
         # Parent yaml lists the parent dir itself as the only entry.
         ts = 1_700_000_000.0
         self._write_parent_yaml(self.TMP_ROOT, str(self.TMP_ROOT), ts)
+        parent_yaml = self.TMP_ROOT / TS_FN
+        parent_mtime_before = parent_yaml.stat().st_mtime
+        parent_bytes_before = parent_yaml.read_bytes()
 
         config = GrovestampsConfig(
             program_name=PROGRAM_NAME,
@@ -72,3 +75,10 @@ class TestParentLoad(BaseTestDir):
         # Child yaml should now exist with a single root-relative entry.
         child_yaml = child_dir / TS_FN
         assert child_yaml.exists()
+
+        # The parent yaml MUST NOT have been written or deleted —
+        # treestamps may load above-root entries but only writes to its
+        # own root_dir's stamp file.
+        assert parent_yaml.exists()
+        assert parent_yaml.stat().st_mtime == parent_mtime_before
+        assert parent_yaml.read_bytes() == parent_bytes_before

--- a/treestamps/tree/load.py
+++ b/treestamps/tree/load.py
@@ -77,7 +77,18 @@ class TreestampsLoad(TreestampsGet):
     ) -> None:
         """Load a single timestamp entry into the cache."""
         try:
-            if abs_path := self._get_absolute_path(timestamps_root, path_str):
+            # Anchor relative entries to the yaml's source dir, then validate
+            # against this tree's ``root_dir``. Using ``timestamps_root`` for
+            # validation lets above-root absolute entries from a parent yaml
+            # leak in (``path == timestamps_root`` is trivially relative to
+            # itself), which then crashes ``dumpf`` because the entry can't
+            # be made relative to ``self.root_dir``. Clamping to
+            # ``self.root_dir`` is the correct semantic: a timestamp set on
+            # an ancestor of the tree applies to the tree as a whole.
+            path = Path(path_str)
+            if not path.is_absolute():
+                path = (timestamps_root / path).absolute()
+            if abs_path := self._get_absolute_path(self.root_dir, path):
                 # Compare against an exact-key entry only — public get() walks
                 # ancestors which is the wrong semantic at load time.
                 old_ts = self._timestamps.get(abs_path)


### PR DESCRIPTION
## Summary

When a tree's `root_dir` has an ancestor whose `.PROGRAM_treestamps.yaml` contains an entry equal to that ancestor (or anywhere above `root_dir`), `loadf_tree` walks up, finds the parent yaml, and feeds its entries to `_load_timestamp_entry` with `timestamps_root` set to the parent dir.

`_load_timestamp_entry` called `_get_absolute_path(timestamps_root, path_str)` — i.e. validated the path against the *yaml's source dir* — so for the parent's own absolute path, `path.is_relative_to(timestamps_root)` was trivially True and the entry got stored above-root. On `dumpf`, `_serialize_timestamps` then called `abs_path.relative_to(self.root_dir)` and crashed:

```
ValueError: '/tmp/picopt-tests' is not in the subpath of '/tmp/picopt-tests/child'
```

This is what made `picopt`'s `tests/test_timestamps.py::TestTimestamps::test_timestamp_parents` start failing on v4.

## Fix

Anchor relative entries to `timestamps_root` (preserving the yaml-anchored semantic for relative paths), then validate against `self.root_dir`. The existing `root_dir.is_relative_to(path)` branch in `_get_absolute_path` then clamps above-root entries down to `root_dir` — matching the v3 semantic that an ancestor timestamp applies to the whole tree.

```python
path = Path(path_str)
if not path.is_absolute():
    path = (timestamps_root / path).absolute()
if abs_path := self._get_absolute_path(self.root_dir, path):
    ...
```

## Test plan

- [x] Added `tests/integration/test_parent_load.py` that writes a parent yaml whose only entry points at the parent itself, loads it via `Grovestamps` rooted on a child dir, asserts the lookup inherits the parent ts, and calls `dumpf()` (the crash site).
- [x] Verified the new test fails on `develop` (without the fix) with the exact `ValueError` and passes with the fix applied.
- [x] `uv run pytest` — 28/28 pass.
- [x] `uv run ruff check` — clean.
- [x] `uv run basedpyright treestamps/tree/load.py` — clean.

Bumps version to 4.0.2 with a NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)